### PR TITLE
Made a few minor changes/fixes and added full screen

### DIFF
--- a/core/src/main/java/io/github/universityTycoon/Main.java
+++ b/core/src/main/java/io/github/universityTycoon/Main.java
@@ -2,6 +2,8 @@ package io.github.universityTycoon;
 
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.viewport.FitViewport;
@@ -15,6 +17,8 @@ public class Main extends Game {
     public MainScreen gameScreen;
     public FirstScreen menuScreen;
 
+    public Boolean fullScreen;
+
     public void create() {
 
         //Create instances of the screens, this allows access to non-static variables
@@ -22,6 +26,8 @@ public class Main extends Game {
         menuScreen = new FirstScreen(this);
 
         batch = new SpriteBatch();
+
+        fullScreen = false;
 
         // use libGDX's default font
         font = new BitmapFont(Gdx.files.internal("ui/font.fnt"),
@@ -42,6 +48,14 @@ public class Main extends Game {
     }
 
     public void render() {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.F11)){
+            fullScreen = Gdx.graphics.isFullscreen();
+            Graphics.DisplayMode currentMode = Gdx.graphics.getDisplayMode();
+            if (fullScreen)
+                Gdx.graphics.setWindowedMode(currentMode.width, currentMode.height);
+            else
+                Gdx.graphics.setFullscreenMode(currentMode);
+        }
         font.getData().setScale(0.003f, 0.003f);
         super.render();
     }

--- a/core/src/main/java/io/github/universityTycoon/MainScreen.java
+++ b/core/src/main/java/io/github/universityTycoon/MainScreen.java
@@ -58,7 +58,7 @@ public class MainScreen implements Screen {
     public void show() {
         batch = new SpriteBatch();
         shapeRenderer = new ShapeRenderer();
-        viewport = new FitViewport(1920, 1080);
+        viewport = new FitViewport(16, 9);
 
         mousePos = new Vector2(0,0);
 
@@ -74,7 +74,9 @@ public class MainScreen implements Screen {
     public void render(float v) {
         input();
         logic();
+        batch.begin();
         draw();
+        batch.end();
     }
 
     @Override
@@ -102,7 +104,7 @@ public class MainScreen implements Screen {
             timeSeconds -= delta;
         }
         // This is an example of how the game can be paused
-        // To do so in a different file, use gameScreen.timeSeconds
+        // To do so in a Main, use gameScreen.timeSeconds
         // and gameScreen.getTimeSeconds
         /*
         if (timeSeconds < 290) {
@@ -119,15 +121,17 @@ public class MainScreen implements Screen {
         ScreenUtils.clear(Color.BLACK);
         viewport.apply();
 
-        batch.setProjectionMatrix(viewport.getCamera().combined);
-        batch.begin();
-
         float worldWidth = viewport.getWorldWidth();
         float worldHeight = viewport.getWorldHeight();
 
-        batch.draw(backgroundTexture, 0, worldHeight - 840, worldWidth, 840);
-        game.font.draw(batch, time, 960, 100);
-        batch.end();
+
+        batch.setProjectionMatrix(viewport.getCamera().combined);
+
+
+        batch.draw(backgroundTexture, 0, 2, 16, 7);
+        game.font.draw(batch, time, 7.6f, 8.5f);
+
+
 
         for (Rectangle tiles : activeTiles) {
             shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);


### PR DESCRIPTION
-Added F11 to full screen
-Moved batch.begin() and outside the draw() method, and surrounding its call.
- Changed viewports to 16 by 9, rather than 1920 by 1080.
- To convert: take the pixel coordinates you want, and divide both by 120.

Known bugs/issues:

- Clicking on screen to place something doesn't always seem to register and/or place the rectangle, but moving the mouse within the tile and clicking somewhere different may work.
- The top row of tiles are 90% of screen.
- Placing any rectangle the way it's set up breaks everything, they aren't in the sprite batch, so the timer stops displaying.