### PR TITLE
Mostly fixed building placements

### DIFF
--- a/core/src/main/java/io/github/universityTycoon/MainScreen.java
+++ b/core/src/main/java/io/github/universityTycoon/MainScreen.java
@@ -137,11 +137,16 @@ public class MainScreen implements Screen {
     }
 
     private void placeBuilding() {
-        int tileLocationX = (int)(gameModel.getTilesWide() * mousePos.x / viewport.getScreenWidth());
-        int tileLocationY = (int)(gameModel.getTilesHigh() * mousePos.y / viewport.getScreenHeight());
+        // Not sure why, but this if statement is needed to prevent attempting to place a building,
+        // off to the left of the screen.
+        if ((mousePos.x >= 30))  {
+            int tileLocationX = (int)(-2 +gameModel.getTilesWide() * mousePos.x / viewport.getScreenWidth() );
+            int tileLocationY = (int)(2 +gameModel.getTilesHigh() * mousePos.y / viewport.getScreenHeight());
 
-        // Defaulting to accommodation building for now
-        gameModel.mapController.addBuilding(new AccommodationBuilding(gameModel.getGameTimeGMT()), tileLocationX, tileLocationY);
+            // Defaulting to accommodation building for now
+            gameModel.mapController.addBuilding(new AccommodationBuilding(gameModel.getGameTimeGMT()), tileLocationX, tileLocationY);
+        }
+
     }
 
     private void drawMapObjects() {

--- a/core/src/main/java/io/github/universityTycoon/MapController.java
+++ b/core/src/main/java/io/github/universityTycoon/MapController.java
@@ -19,9 +19,73 @@ public class MapController {
     }
 
     public void addBuilding(Building building, int xPos, int yPos) {
-        if (mapObjects[xPos][yPos] == null) {
-            mapObjects[xPos][yPos] = building;
+        // the following if statement, if checkSurroundingTiles worked should be as follows
+        /*
+         if ((mapObjects[xPos][yPos] == null) && checkSurroundingTiles(xPos, yPos) &&
+         (xPos < 61) && (yPos > 5) && (yPos < 23)) {
+         mapObjects[xPos][yPos] = building;
+         }
+         */
+
+        // However I've constrained placement of tiles on the left to prevent crashing
+
+        if ((mapObjects[xPos][yPos] == null) &&
+            (xPos < 61) && (xPos > 2) && (yPos > 5) && (yPos < 23)) {
+            if  (checkSurroundingTiles(xPos, yPos)) {
+                mapObjects[xPos][yPos] = building;
+            }
         }
+
+        }
+
+    public boolean checkSurroundingTiles(int xPos, int yPos) {
+            return (
+                // checks the tiles 1  above and 1 below
+                (mapObjects[xPos][yPos+1] == null) && (mapObjects[xPos][yPos-1] == null) &&
+                // checks the tiles 2  above and 2 below
+                (mapObjects[xPos][yPos+2] == null) && (mapObjects[xPos][yPos-2] == null) &&
+
+                // checks the tiles 1 right, 1 above and 1 below
+                (mapObjects[xPos+1][yPos+1] == null) && (mapObjects[xPos+1][yPos-1] == null) &&
+                // checks the tiles 1 right, 2 above and 2 below
+                (mapObjects[xPos+1][yPos+2] == null) && (mapObjects[xPos+1][yPos-2] == null) &&
+
+                // checks the tiles 1 left, 1 above and 1 below
+                (mapObjects[xPos-1][yPos+1] == null) && (mapObjects[xPos-1][yPos-1] == null) &&
+                // checks the tiles 1 left, 2 above and 2 below
+                (mapObjects[xPos-1][yPos+2] == null) && (mapObjects[xPos-1][yPos-2] == null) &&
+
+                // checks the tiles 2 right, 1 above and 1 below
+                (mapObjects[xPos+2][yPos+1] == null) && (mapObjects[xPos+2][yPos-1] == null) &&
+                // checks the tiles 2 right, 2 above and 2 below
+                (mapObjects[xPos+2][yPos+2] == null) && (mapObjects[xPos+2][yPos-2] == null) &&
+
+                // checks the tiles 2 left, 1 above and 1 below
+                (mapObjects[xPos-2][yPos+1] == null) && (mapObjects[xPos-2][yPos-1] == null) &&
+                // checks the tiles 2 left, 2 above and 2 below
+                (mapObjects[xPos-2][yPos+2] == null) && (mapObjects[xPos-2][yPos-2] == null) &&
+
+                // checks the tiles 3 right, 1 above and 1 below
+                (mapObjects[xPos + 3][yPos + 1] == null) && (mapObjects[xPos + 3][yPos - 1] == null) &&
+                // checks the tiles 3 right, 2 above and 2 below
+                (mapObjects[xPos + 3][yPos + 2] == null) && (mapObjects[xPos + 3][yPos - 2] == null) &&
+
+                // checks the tiles 3 left, 1 above and 1 below
+                (mapObjects[xPos - 3][yPos + 1] == null) && (mapObjects[xPos - 3][yPos - 1] == null) &&
+                // checks the tiles 3, 2 above and 2 below
+                (mapObjects[xPos - 3][yPos + 2] == null) && (mapObjects[xPos - 3][yPos - 2] == null) &&
+
+                // checks the tiles 1 and 2 right
+                (mapObjects[xPos + 1][yPos] == null) && (mapObjects[xPos + 2][yPos] == null) &&
+                // checks the tiles 1 and 2 left
+                (mapObjects[xPos - 1][yPos] == null) && (mapObjects[xPos - 2][yPos] == null) &&
+                // checks the tiles 3 right and 3 left
+                (mapObjects[xPos + 3][yPos] == null) && (mapObjects[xPos - 3][yPos] == null)
+
+
+        );
+
+
     }
 
     // Call this to ensure buildings progress from under construction to complete


### PR DESCRIPTION
You now can't overlap buildings, and they're confined to the map.

However, I am not smart enough to think of a better way to check for collisions, as we add buildings to an array before doing anything, which makes it really difficult to use in built overlap/collision features. I couldn't summon the effort to sort all the boolean clauses by x values to prevent index out of range errors, so as a temporary fix I've just prevented placing buildings at the left.

I also prevented (intentionally for once) placing buildings at the top, as to not get in the way of any information we display up there.

Also the current terrible overlap check will only work for buildings with the same dimensions.

I also fixed the cursor placing buildings diagonally right of the click, this seemed to work without any issue which was a surprising treat.